### PR TITLE
Changes to Authentication, Repo API and User API

### DIFF
--- a/lib/api/phpGitHubApiRepo.php
+++ b/lib/api/phpGitHubApiRepo.php
@@ -14,7 +14,7 @@ class phpGitHubApiRepo extends phpGitHubApiAbstract
 {
   /**
    * Search repos by keyword
-   * http://develop.github.com/p/repos.html#searching_repositories
+   * http://develop.github.com/p/repo.html
    *
    * @param   string  $query            the search query
    * @param   string  $language         takes the same values as the language drop down on http://github.com/search
@@ -33,7 +33,7 @@ class phpGitHubApiRepo extends phpGitHubApiAbstract
 
   /**
    * Get extended information about a repository by its username and repo name
-   * http://develop.github.com/p/repos.html#show_repo_info
+   * http://develop.github.com/p/repo.html
    *
    * @param   string  $username         the user who owns the repo
    * @param   string  $repo             the name of the repo
@@ -48,7 +48,7 @@ class phpGitHubApiRepo extends phpGitHubApiAbstract
 
   /**
    * Get the repositories of a user
-   * http://develop.github.com/p/repos.html#list_all_repositories
+   * http://develop.github.com/p/repo.html
    *
    * @param   string  $username         the username
    * @return  array                     list of the user repos
@@ -62,7 +62,7 @@ class phpGitHubApiRepo extends phpGitHubApiAbstract
 
   /**
    * Get the tags of a repository
-   * http://develop.github.com/p/repos.html#repository_refs
+   * http://develop.github.com/p/repo.html
    *
    * @param   string  $username         the username
    * @param   string  $repo             the name of the repo
@@ -77,7 +77,7 @@ class phpGitHubApiRepo extends phpGitHubApiAbstract
 
   /**
    * Get the contributors of a repository
-   * http://develop.github.com/p/repos.html
+   * http://develop.github.com/p/repo.html
    *
    * @param   string  $username         the username
    * @param   string  $repo             the name of the repo
@@ -98,7 +98,7 @@ class phpGitHubApiRepo extends phpGitHubApiAbstract
 
   /**
    * Get the branches of a repository
-   * http://develop.github.com/p/repos.html#repository_refs
+   * http://develop.github.com/p/repo.html
    *
    * @param   string  $username         the username
    * @param   string  $repo             the name of the repo

--- a/lib/api/phpGitHubApiRepo.php
+++ b/lib/api/phpGitHubApiRepo.php
@@ -50,7 +50,8 @@ class phpGitHubApiRepo extends phpGitHubApiAbstract
    *
    * @return  array                     list of repositories
    */
-  public function getPushableRepos() {
+  public function getPushableRepos()
+  {
     $response = $this->api->get('repos/pushable');
 
     return $response['repositories'];
@@ -134,7 +135,8 @@ class phpGitHubApiRepo extends phpGitHubApiAbstract
    * @param   array   $values           the key => value pairs to post
    * @return  array                     informations about the repo
    */
-  public function setRepoInfo($username, $repo, $values) {
+  public function setRepoInfo($username, $repo, $values)
+  {
     $response = $this->api->post('repos/show/'.urlencode($username).'/'.urlencode($repo), $values);
 
     return $response['repository'];
@@ -147,7 +149,8 @@ class phpGitHubApiRepo extends phpGitHubApiAbstract
    * @param   string  $repo             the name of the repo
    * @return  array                     informations about the repo
    */
-  public function setPublic($repo) {
+  public function setPublic($repo)
+  {
     $response = $this->api->get('repos/set/public/'.urlencode($repo));
 
     return $response['repository'];
@@ -160,7 +163,8 @@ class phpGitHubApiRepo extends phpGitHubApiAbstract
    * @param   string  $repo             the name of the repo
    * @return  array                     informations about the repo
    */
-  public function setPrivate($repo) {
+  public function setPrivate($repo)
+  {
     $response = $this->api->get('repos/set/private/'.urlencode($repo));
 
     return $response['repository'];
@@ -172,7 +176,8 @@ class phpGitHubApiRepo extends phpGitHubApiAbstract
    * @param   string  $repo             the name of the repo
    * @return  array                     the list of deploy keys
    */
-  public function getDeployKeys($repo) {
+  public function getDeployKeys($repo)
+  {
     $response = $this->api->get('repos/keys/'.urlencode($repo));
 
     return $response['public_keys'];
@@ -186,7 +191,8 @@ class phpGitHubApiRepo extends phpGitHubApiAbstract
    * @param   string  $key              the public key data
    * @return  array                     the list of deploy keys
    */
-  public function addDeployKey($repo, $title, $key) {
+  public function addDeployKey($repo, $title, $key)
+  {
     $response = $this->api->post('repos/key/'.urlencode($repo) . '/add', array(
       'title' => $title,
       'key' => $key
@@ -202,7 +208,8 @@ class phpGitHubApiRepo extends phpGitHubApiAbstract
    * @param   string  $id               the the id of the key to remove
    * @return  array                     the list of deploy keys
    */
-  public function removeDeployKey($repo, $id) {
+  public function removeDeployKey($repo, $id)
+  {
     $response = $this->api->post('repos/key/'.urlencode($repo) . '/remove', array(
       'id' => $id,
     ));
@@ -218,7 +225,8 @@ class phpGitHubApiRepo extends phpGitHubApiAbstract
    * @param   string  $repo             the name of the repo
    * @return  array                     list of the repo collaborators
    */
-  public function getRepoCollaborators($username, $repo) {
+  public function getRepoCollaborators($username, $repo)
+  {
     $response = $this->api->get('repos/show/'.urlencode($username).'/'.urlencode($repo).'/collaborators');
 
     return $response['collaborators'];
@@ -232,7 +240,8 @@ class phpGitHubApiRepo extends phpGitHubApiAbstract
    * @param   string  $username         the user who should be added as a collaborator
    * @return  array                     list of the repo collaborators
    */
-  public function addRepoCollaborator($username, $repo) {
+  public function addRepoCollaborator($username, $repo)
+  {
     $response = $this->api->post('repos/collaborators/'.urlencode($repo).'/add/' . urlencode($username));
 
     return $response['collaborators'];
@@ -246,7 +255,8 @@ class phpGitHubApiRepo extends phpGitHubApiAbstract
    * @param   string  $username         the user who should be removed as a collaborator
    * @return  array                     list of the repo collaborators
    */
-  public function removeRepoCollaborator($username, $repo) {
+  public function removeRepoCollaborator($username, $repo)
+  {
     $response = $this->api->post('repos/collaborators/'.urlencode($repo).'/remove/' . urlencode($username));
 
     return $response['collaborators'];
@@ -260,7 +270,8 @@ class phpGitHubApiRepo extends phpGitHubApiAbstract
    * @param   string  $repo             the name of the repo
    * @return  array                     informations about the repo
    */
-  public function watch($username, $repo) {
+  public function watch($username, $repo)
+  {
     $response = $this->api->get('repos/watch/'.urlencode($username).'/'.urlencode($repo));
 
     return $response['repository'];
@@ -274,7 +285,8 @@ class phpGitHubApiRepo extends phpGitHubApiAbstract
    * @param   string  $repo             the name of the repo
    * @return  array                     informations about the repo
    */
-  public function unwatch($username, $repo) {
+  public function unwatch($username, $repo)
+  {
     $response = $this->api->get('repos/unwatch/'.urlencode($username).'/'.urlencode($repo));
 
     return $response['repository'];
@@ -288,7 +300,8 @@ class phpGitHubApiRepo extends phpGitHubApiAbstract
    * @param   string  $repo             the name of the repo
    * @return  array                     informations about the newly forked repo
    */
-  public function fork($username, $repo) {
+  public function fork($username, $repo)
+  {
     $response = $this->api->get('repos/fork/'.urlencode($username).'/'.urlencode($repo));
 
     return $response['repository'];
@@ -333,7 +346,8 @@ class phpGitHubApiRepo extends phpGitHubApiAbstract
    * @param   string  $repo             the name of the repo
    * @return  array                     list of the repo watchers
    */
-  public function getRepoWatchers($username, $repo) {
+  public function getRepoWatchers($username, $repo)
+  {
     $response = $this->api->get('repos/show/'.urlencode($username).'/'.urlencode($repo).'/watchers');
 
     return $response['watchers'];
@@ -347,7 +361,8 @@ class phpGitHubApiRepo extends phpGitHubApiAbstract
    * @param   string  $repo             the name of the repo
    * @return  array                     list of the repo forks
    */
-  public function getRepoNetwork($username, $repo) {
+  public function getRepoNetwork($username, $repo)
+  {
     $response = $this->api->get('repos/show/'.urlencode($username).'/'.urlencode($repo).'/network');
 
     return $response['network'];
@@ -361,7 +376,8 @@ class phpGitHubApiRepo extends phpGitHubApiAbstract
    * @param   string  $repo             the name of the repo
    * @return  array                     list of the languages
    */
-  public function getRepoLanguages($username, $repo) {
+  public function getRepoLanguages($username, $repo)
+  {
     $response = $this->api->get('repos/show/'.urlencode($username).'/'.urlencode($repo).'/languages');
 
     return $response['languages'];

--- a/lib/api/phpGitHubApiRepo.php
+++ b/lib/api/phpGitHubApiRepo.php
@@ -240,7 +240,7 @@ class phpGitHubApiRepo extends phpGitHubApiAbstract
    * @param   string  $username         the user who should be added as a collaborator
    * @return  array                     list of the repo collaborators
    */
-  public function addRepoCollaborator($username, $repo)
+  public function addRepoCollaborator($repo, $username)
   {
     $response = $this->api->post('repos/collaborators/'.urlencode($repo).'/add/' . urlencode($username));
 

--- a/lib/api/phpGitHubApiRepo.php
+++ b/lib/api/phpGitHubApiRepo.php
@@ -47,6 +47,134 @@ class phpGitHubApiRepo extends phpGitHubApiAbstract
   }
 
   /**
+   * Set information of a repository
+   * http://develop.github.com/p/repo.html
+   *
+   * @param   string  $username         the user who owns the repo
+   * @param   string  $repo             the name of the repo
+   * @param   array   $values           the key => value pairs to post
+   * @return  array                     informations about the repo
+   */
+  public function setRepoInfo($username, $repo, $values) {
+    $response = $this->api->post('repos/show/'.urlencode($username).'/'.urlencode($repo), $values);
+
+    return $response['repository'];
+  }
+  
+
+  /**
+   * Make the authenticated user watch a repository
+   * http://develop.github.com/p/repo.html
+   *
+   * @param   string  $username         the user who owns the repo
+   * @param   string  $repo             the name of the repo
+   * @return  array                     informations about the repo
+   */
+  public function watch($username, $repo) {
+    $response = $this->api->get('repos/watch/'.urlencode($username).'/'.urlencode($repo));
+
+    return $response['repository'];
+  }
+  
+  /**
+   * Make the authenticated user unwatch a repository
+   * http://develop.github.com/p/repo.html
+   *
+   * @param   string  $username         the user who owns the repo
+   * @param   string  $repo             the name of the repo
+   * @return  array                     informations about the repo
+   */
+  public function unwatch($username, $repo) {
+    $response = $this->api->get('repos/unwatch/'.urlencode($username).'/'.urlencode($repo));
+
+    return $response['repository'];
+  }
+
+  /**
+   * Make the authenticated user fork a repository
+   * http://develop.github.com/p/repo.html
+   *
+   * @param   string  $username         the user who owns the repo
+   * @param   string  $repo             the name of the repo
+   * @return  array                     informations about the newly forked repo
+   */
+  public function fork($username, $repo) {
+    $response = $this->api->get('repos/fork/'.urlencode($username).'/'.urlencode($repo));
+
+    return $response['repository'];
+  }
+
+  /**
+   * Set the visibility of a repostory to public
+   * http://develop.github.com/p/repo.html
+   *
+   * @param   string  $repo             the name of the repo
+   * @return  array                     informations about the repo
+   */
+  public function setPublic($repo) {
+    $response = $this->api->get('repos/set/public/'.urlencode($repo));
+
+    return $response['repository'];
+  }
+
+  /**
+   * Set the visibility of a repostory to private
+   * http://develop.github.com/p/repo.html
+   *
+   * @param   string  $repo             the name of the repo
+   * @return  array                     informations about the repo
+   */
+  public function setPrivate($repo) {
+    $response = $this->api->get('repos/set/private/'.urlencode($repo));
+
+    return $response['repository'];
+  }
+
+  /**
+   * Get the list of deploy keys for a repository
+   *
+   * @param   string  $repo             the name of the repo
+   * @return  array                     the list of deploy keys
+   */
+  public function getDeployKeys($repo) {
+    $response = $this->api->get('repos/keys/'.urlencode($repo));
+
+    return $response['public_keys'];
+  }
+
+  /**
+   * Add a deploy key for a repository
+   *
+   * @param   string  $repo             the name of the repo
+   * @param   string  $title            the title of the key
+   * @param   string  $key              the public key data
+   * @return  array                     the list of deploy keys
+   */
+  public function addDeployKey($repo, $title, $key) {
+    $response = $this->api->post('repos/key/'.urlencode($repo) . '/add', array(
+      'title' => $title,
+      'key' => $key
+    ));
+
+    return $response['public_keys'];
+  }
+
+  /**
+   * Delete a deploy key from a repository
+   *
+   * @param   string  $repo             the name of the repo
+   * @param   string  $id               the the id of the key to remove
+   * @return  array                     the list of deploy keys
+   */
+  public function removeDeployKey($repo, $id) {
+    $response = $this->api->post('repos/key/'.urlencode($repo) . '/remove', array(
+      'id' => $id,
+    ));
+
+    return $response['public_keys'];
+  }
+
+  /**
    * Get the repositories of a user
    * http://develop.github.com/p/repo.html
    *
@@ -64,7 +192,7 @@ class phpGitHubApiRepo extends phpGitHubApiAbstract
    * Get the tags of a repository
    * http://develop.github.com/p/repo.html
    *
-   * @param   string  $username         the username
+   * @param   string  $username         the user who owns the repo
    * @param   string  $repo             the name of the repo
    * @return  array                     list of the repo tags
    */
@@ -76,10 +204,52 @@ class phpGitHubApiRepo extends phpGitHubApiAbstract
   }
 
   /**
+   * Get the watchers of a repository
+   * http://develop.github.com/p/repo.html
+   *
+   * @param   string  $username         the user who owns the repo
+   * @param   string  $repo             the name of the repo
+   * @return  array                     list of the repo watchers
+   */
+  public function getRepoWatchers($username, $repo) {
+    $response = $this->api->get('repos/show/'.urlencode($username).'/'.urlencode($repo).'/watchers');
+
+    return $response['watchers'];
+  }
+  
+  /**
+   * Get the network (a list of forks) of a repository
+   * http://develop.github.com/p/repo.html
+   *
+   * @param   string  $username         the user who owns the repo
+   * @param   string  $repo             the name of the repo
+   * @return  array                     list of the repo forks
+   */
+  public function getRepoNetwork($username, $repo) {
+    $response = $this->api->get('repos/show/'.urlencode($username).'/'.urlencode($repo).'/network');
+
+    return $response['network'];
+  }
+
+  /**
+   * Get the language breakdown of a repository
+   * http://develop.github.com/p/repo.html
+   *
+   * @param   string  $username         the user who owns the repo
+   * @param   string  $repo             the name of the repo
+   * @return  array                     list of the languages
+   */
+  public function getRepoLanguages($username, $repo) {
+    $response = $this->api->get('repos/show/'.urlencode($username).'/'.urlencode($repo).'/languages');
+
+    return $response['languages'];
+  }
+
+  /**
    * Get the contributors of a repository
    * http://develop.github.com/p/repo.html
    *
-   * @param   string  $username         the username
+   * @param   string  $username         the user who owns the repo
    * @param   string  $repo             the name of the repo
    * @param   boolean $includingNonGithubUsers by default, the list only shows GitHub users. You can include non-users too by setting this to true
    * @return  array                     list of the repo contributors
@@ -94,6 +264,59 @@ class phpGitHubApiRepo extends phpGitHubApiAbstract
     $response = $this->api->get($url);
 
     return $response['contributors'];
+  }
+
+  /**
+   * Get the collaborators of a repository
+   * http://develop.github.com/p/repo.html
+   *
+   * @param   string  $username         the user who owns the repo
+   * @param   string  $repo             the name of the repo
+   * @return  array                     list of the repo collaborators
+   */
+  public function getRepoCollaborators($username, $repo) {
+    $response = $this->api->get('repos/show/'.urlencode($username).'/'.urlencode($repo).'/collaborators');
+
+    return $response['collaborators'];
+  }
+
+  /**
+   * Add a collaborator to a repository
+   * http://develop.github.com/p/repo.html
+   *
+   * @param   string  $repo             the name of the repo
+   * @param   string  $username         the user who should be added as a collaborator
+   * @return  array                     list of the repo collaborators
+   */
+  public function addRepoCollaborator($username, $repo) {
+    $response = $this->api->post('repos/collaborators/'.urlencode($repo).'/add/' . urlencode($username));
+
+    return $response['collaborators'];
+  }
+
+  /**
+   * Delete a collaborator from a repository
+   * http://develop.github.com/p/repo.html
+   *
+   * @param   string  $repo             the name of the repo
+   * @param   string  $username         the user who should be removed as a collaborator
+   * @return  array                     list of the repo collaborators
+   */
+  public function removeRepoCollaborator($username, $repo) {
+    $response = $this->api->post('repos/collaborators/'.urlencode($repo).'/remove/' . urlencode($username));
+
+    return $response['collaborators'];
+  }
+
+  /**
+   * Get a list of the repositories that the authenticated user can push to
+   *
+   * @return  array                     list of repositories
+   */
+  public function getPushableRepos() {
+    $response = $this->api->get('repos/pushable');
+
+    return $response['repositories'];
   }
 
   /**

--- a/lib/api/phpGitHubApiRepo.php
+++ b/lib/api/phpGitHubApiRepo.php
@@ -137,7 +137,11 @@ class phpGitHubApiRepo extends phpGitHubApiAbstract
    */
   public function setRepoInfo($username, $repo, $values)
   {
-    $response = $this->api->post('repos/show/'.urlencode($username).'/'.urlencode($repo), $values);
+    $post = array();
+    foreach ($values as $key => $value) {
+      $post['values['.$key.']'] = $value;
+    }
+    $response = $this->api->post('repos/show/'.urlencode($username).'/'.urlencode($repo), $post);
 
     return $response['repository'];
   }

--- a/lib/api/phpGitHubApiRepo.php
+++ b/lib/api/phpGitHubApiRepo.php
@@ -137,11 +137,7 @@ class phpGitHubApiRepo extends phpGitHubApiAbstract
    */
   public function setRepoInfo($username, $repo, $values)
   {
-    $post = array();
-    foreach ($values as $key => $value) {
-      $post['values['.$key.']'] = $value;
-    }
-    $response = $this->api->post('repos/show/'.urlencode($username).'/'.urlencode($repo), $post);
+    $response = $this->api->post('repos/show/'.urlencode($username).'/'.urlencode($repo), array('values' => $values));
 
     return $response['repository'];
   }

--- a/lib/api/phpGitHubApiRepo.php
+++ b/lib/api/phpGitHubApiRepo.php
@@ -255,7 +255,7 @@ class phpGitHubApiRepo extends phpGitHubApiAbstract
    * @param   string  $username         the user who should be removed as a collaborator
    * @return  array                     list of the repo collaborators
    */
-  public function removeRepoCollaborator($username, $repo)
+  public function removeRepoCollaborator($repo, $username)
   {
     $response = $this->api->post('repos/collaborators/'.urlencode($repo).'/remove/' . urlencode($username));
 

--- a/lib/api/phpGitHubApiUser.php
+++ b/lib/api/phpGitHubApiUser.php
@@ -127,6 +127,42 @@ class phpGitHubApiUser extends phpGitHubApiAbstract
   }
 
   /**
+   * Get the authenticated user public keys. Requires authentication
+   *
+   * @return  array                     list of public keys of the user
+   */
+  public function getKeys() 
+  {
+    $response = $this->api->get('user/keys');
+    
+    return $response['public_keys'];
+  }
+
+  /**
+   * Add a public key to the authenticated user. Requires authentication.
+   *
+   * @return  array                     ist of public keys of the user
+   */
+  public function addKey($title, $key)
+  {
+    $response = $this->api->post('user/key/add', array('title' => $title, 'key' => $key));
+
+    return $response['public_keys'];
+  }
+
+  /**
+   * Remove a public key from the authenticated user. Requires authentication.
+   *
+   * @return  array                     ist of public keys of the user
+   */
+  public function removeKey($id)
+  {
+    $response = $this->api->post('user/key/remove', array('id' => $id));
+
+    return $response['public_keys'];
+  }
+
+  /**
    * Get the authenticated user emails. Requires authentication.
    *
    * @return  array                     list of authenticated user emails

--- a/lib/phpGitHubApi.php
+++ b/lib/phpGitHubApi.php
@@ -14,6 +14,24 @@
 class phpGitHubApi
 {
   /**
+   * Constant for authentication method. Indicates the default, but deprecated
+   * login with username and token in URL.
+   */
+  const AUTH_URL_TOKEN = 'url_token';
+  
+  /**
+   * Constant for authentication method. Indicates the new favored login method
+   * with username and password via HTTP Authentication.
+   */
+  const AUTH_HTTP_PASSWORD = 'http_password';
+  
+  /**
+   * Constant for authentication method. Indicates the new login method with
+   * with username and token via HTTP Authentication.
+   */
+  const AUTH_HTTP_TOKEN = 'http_token';
+  
+  /**
    * The request instance used to communicate with GitHub
    * @var phpGitHubApiRequest
    */
@@ -45,14 +63,20 @@ class phpGitHubApi
    * Authenticate a user for all next requests
    *
    * @param  string         $login      GitHub username
-   * @param  string         $token      GitHub private token
+   * @param  string         $secret     GitHub private token or Github password if $method == AUTH_HTTP_PASSWORD
+   * @param  string         $method     One of the AUTH_* class constants
+   *
    * @return phpGitHubApi               fluent interface
    */
-  public function authenticate($login, $token)
+  public function authenticate($login, $secret, $method = NULL)
   {
+    if (!$method) {
+      $method = self::AUTH_URL_TOKEN;
+    }
     $this->getRequest()
+    ->setOption('auth_method', $method)
     ->setOption('login', $login)
-    ->setOption('token', $token);
+    ->setOption('secret', $secret);
 
     return $this;
   }
@@ -64,7 +88,7 @@ class phpGitHubApi
    */
   public function deAuthenticate()
   {
-    return $this->authenticate(null, null);
+    return $this->authenticate(null, null, null);
   }
   
   /**

--- a/lib/request/phpGitHubApiRequest.php
+++ b/lib/request/phpGitHubApiRequest.php
@@ -151,6 +151,7 @@ class phpGitHubApiRequest
           $curlOptions += array(
             CURLOPT_USERPWD => $this->options['login'] . '/token:' . $this->options['secret'],
           );
+          break;
         case phpGitHubApi::AUTH_URL_TOKEN:
         default:
           $parameters = array_merge(array(

--- a/lib/request/phpGitHubApiRequest.php
+++ b/lib/request/phpGitHubApiRequest.php
@@ -136,16 +136,31 @@ class phpGitHubApiRequest
       ':format'   => $this->options['format'],
       ':path'     => trim($apiPath, '/')
     ));
+    
+    $curlOptions = array();
 
     if($this->options['login'])
     {
-      $parameters = array_merge(array(
-        'login' => $this->options['login'],
-        'token' => $this->options['token']
-      ), $parameters);
-    }
+      switch($this->options['auth_method']) {
+        case phpGitHubApi::AUTH_HTTP_PASSWORD:
+          $curlOptions += array(
+            CURLOPT_USERPWD => $this->options['login'] . ':' . $this->options['secret'],
+          );
+          break;
+        case phpGitHubApi::AUTH_HTTP_TOKEN:
+          $curlOptions += array(
+            CURLOPT_USERPWD => $this->options['login'] . '/token:' . $this->options['secret'],
+          );
+        case phpGitHubApi::AUTH_URL_TOKEN:
+        default:
+          $parameters = array_merge(array(
+            'login' => $this->options['login'],
+            'token' => $this->options['secret']
+          ), $parameters);
+          break;
+      }
 
-    $curlOptions = array();
+    }
 
     if (!empty($parameters))
     {

--- a/test/authenticationTest.php
+++ b/test/authenticationTest.php
@@ -2,7 +2,7 @@
 require_once dirname(__FILE__).'/vendor/lime.php';
 require_once dirname(__FILE__).'/../lib/phpGitHubApi.php';
 
-$t = new lime_test(3);
+$t = new lime_test(4);
 
 $username = 'ornicartest';
 $token    = 'fd8144e29b4a85e9487d1cacbcd4e26c';
@@ -16,11 +16,19 @@ $user = $api->getUserApi()->show($username);
 
 $t->ok(!isset($user['plan']), 'User plan is not available');
 
-$t->comment('Authenticate '.$username);
+$t->comment('Authenticate '.$username.' with default authentication method (should be username and token in URL)');
 
 $api->authenticate($username, $token);
 
 $t->comment('Get user with authentication');
+
+$user = $api->getUserApi()->show($username);
+
+$t->ok(isset($user['plan']), 'User plan is available');
+
+$t->comment('Autentication: '.$username . ' using HTTP Basic Authentication with token');
+
+$api->authenticate($username, $token, phpGitHubApi::AUTH_HTTP_TOKEN);
 
 $user = $api->getUserApi()->show($username);
 

--- a/test/authenticationTest.php
+++ b/test/authenticationTest.php
@@ -2,7 +2,7 @@
 require_once dirname(__FILE__).'/vendor/lime.php';
 require_once dirname(__FILE__).'/../lib/phpGitHubApi.php';
 
-$t = new lime_test(4);
+$t = new lime_test(5);
 
 $username = 'ornicartest';
 $token    = 'fd8144e29b4a85e9487d1cacbcd4e26c';
@@ -33,6 +33,14 @@ $api->authenticate($username, $token, phpGitHubApi::AUTH_HTTP_TOKEN);
 $user = $api->getUserApi()->show($username);
 
 $t->ok(isset($user['plan']), 'User plan is available');
+
+$t->comment('Deauthenticate');
+
+$api->deAuthenticate();
+
+$user = $api->getUserApi()->show($username);
+
+$t->ok(!isset($user['plan']), 'User plan is not available');
 
 $t->comment('Authenticate '.$username.' with bad token');
 

--- a/test/repoTest.php
+++ b/test/repoTest.php
@@ -2,7 +2,7 @@
 require_once dirname(__FILE__).'/vendor/lime.php';
 require_once dirname(__FILE__).'/../lib/phpGitHubApi.php';
 
-$t = new lime_test();
+$t = new lime_test(45);
 
 $username = 'ornicartest';
 $token    = 'fd8144e29b4a85e9487d1cacbcd4e26c';
@@ -23,35 +23,40 @@ $t->is($repos[0]['language'], 'PHP', 'First repo language is Php');
 
 $firstPageRepo = $repos[0]['name'];
 
-$t->comment ('Search repos, specify language and start page');
+$t->comment('Search repos, specify language and start page');
 $repos = $github->getRepoApi()->search('github', 'php', 2);
 $t->isnt($repos[0]['name'], $firstPageRepo);
 $repos = $github->getRepoApi()->search('github', 'JavaScript');
 $t->is($repos[0]['language'], 'JavaScript', 'First repo language is Javascript');
 
 // getUserRepos method
+$t->comment('Search repos, specify user');
 $repos = $github->getRepoApi()->getUserRepos('ornicar');
 $t->ok(count($repos) > 20, 'Found '.count($repos).' repos');
 $t->ok(isset($repos[0]['name']), 'First repo name: '.$repos[0]['name']);
 
-// getPushableRepos method
-$github->authenticate($username, $token, phpGitHubApi::AUTH_HTTP_TOKEN);
-$repos = $github->getRepoApi()->getPushableRepos();
-$t->ok(count($repos) > 0, 'Found '.count($repos).' repos');
-$t->ok(isset($repos[0]['name']), 'First repo name: '.$repos[0]['name']);
-$github->deAuthenticate();
-
 // show method
+$t->comment('Getting info on specific repository');
 $repo = $github->getRepoApi()->show('ornicar', 'php-github-api');
 $t->is($repo['name'], 'php-github-api', 'Found repo: '.$repo['name']);
 
+// getRepoCollaborators method
+$t->comment('Finding the collaborators on a specific repository');
 $collaborators = $github->getRepoApi()->getRepoCollaborators('ornicar', 'php-github-api');
 $t->ok(count($collaborators) > 0, 'Found '.count($collaborators).' collaborators');
 
 // authenticate before repository management tests
+$t->comment('Authentice to be able to test repository management');
 $github->authenticate($username, $token, phpGitHubApi::AUTH_HTTP_TOKEN);
 
+// getPushableRepos method
+$t->comment('Find the repositories, the authenticated user can push to');
+$repos = $github->getRepoApi()->getPushableRepos();
+$t->ok(count($repos) > 0, 'Found '.count($repos).' repos');
+$t->ok(isset($repos[0]['name']), 'First repo name: '.$repos[0]['name']);
+
 // create method
+$t->comment('Create a new repository');
 $info = $github->getRepoApi()->create('NewRepo', 'new repo description', 'http://github.com', true);
 $t->is($info['name'], 'NewRepo', 'Repo created with name "NewRepo"');
 $t->is($info['description'], 'new repo description', 'Repo created with description "new repo description"');
@@ -59,10 +64,12 @@ $t->is($info['homepage'], 'http://github.com', 'Repo created with homepage "http
 $t->is($info['private'], false, 'Repo created is public');
 
 // setRepoInfo method
+$t->comment('Changes an attribute of a repository');
 $info = $github->getRepoApi()->setRepoInfo('ornicartest', 'NewRepo', array('description' => 'changed repo description'));
 $t->is($info['description'], 'changed repo description', 'Repo changed to description "changed repo description"');
 
 // getDeployKeys method empty
+$t->comment('List, add and delete deploy keys on a repository');
 $keys = $github->getRepoApi()->getDeployKeys('NewRepo');
 $t->ok(count($keys) == 0, 'No deploy keys setup on NewRepo');
 
@@ -82,36 +89,79 @@ $t->ok(count($keys) == 1, 'Found 1 deploy keys setup on NewRepo');
 $keys = $github->getRepoApi()->removeDeployKey('NewRepo', $key_id);
 $t->ok(count($keys) == 0, 'Deploy key removed from NewRepo');
 
+// getRepoCollaborators method
+$t->comment('List, add and delete collaborators on a repository');
+$collaborators = $github->getRepoApi()->getRepoCollaborators('ornicartest', 'NewRepo');
+$t->ok(count($collaborators) == 1, 'Found 1 collaborator on NewRepo');
+$t->is($collaborators[0], 'ornicartest', 'ornicartest is the only collaborator');
+
+// addRepoCollaborator method
+$collaborators = $github->getRepoApi()->addRepoCollaborator('NewRepo', 'rolfvandekrol');
+$t->ok(count($collaborators) == 2, 'Added 1 collaborator on NewRepo');
+$t->is($collaborators[1], 'rolfvandekrol', 'Added rolfvandekrol as new collaborator');
+
+// removeRepoCollaborator method
+$collaborators = $github->getRepoApi()->removeRepoCollaborator('NewRepo', 'rolfvandekrol');
+$t->ok(count($collaborators) == 1, 'Removed 1 collaborator from NewRepo');
+$t->is($collaborators[0], 'ornicartest', 'ornicartest is the only collaborator');
+
 // delete method
+$t->comment('Delete a repository');
 $token = $github->getRepoApi()->delete('NewRepo');
 $t->ok(is_string($token), 'String delete_token is returned');
 $response = $github->getRepoApi()->delete('NewRepo', $token);
 $t->is($response['status'], 'deleted', 'Repo is deleted');
 
+// watch method
+$t->comment('Watch a repository');
+$repository = $github->getRepoApi()->watch('ornicar', 'php-git-repo');
+$t->is($repository['name'], 'php-git-repo', 'Watching php-git-repo');
+
+// fork method
+$t->comment('Fork a repository');
+$repository = $github->getRepoApi()->fork('ornicar', 'php-git-repo');
+$t->is($repository['name'], 'php-git-repo', 'Forked php-git-repo');
+$repository = $github->getRepoApi()->delete('php-git-repo', null, true);
+$t->is($response['status'], 'deleted', 'Fork is deleted');
+
+// unwatch method
+$t->comment('Unwatch a repository');
+$repository = $github->getRepoApi()->unwatch('ornicar', 'php-git-repo');
+$t->is($repository['name'], 'php-git-repo', 'Unwatching php-git-repo');
+
 // deauthenticate back to anonymous state
+$t->comment('Deauthenticating');
 $github->deAuthenticate();
 
-// getRepo
+// getRepoContributors method
+$t->comment('Get contributors for a repository');
 $contributors = $github->getRepoApi()->getRepoContributors('ornicar', 'php-github-api');
 $t->ok(count($contributors) > 2, 'Found '.count($contributors).' contributors');
 $t->is($contributors[0]['login'], 'ornicar', 'First contributor is ornicar');
 
-$contributors = $github->getRepoApi()->getRepoContributors('ornicar', 'php-github-api', true);
-$t->ok(count($contributors) > 2, 'Found '.count($contributors).' contributors');
-$t->is($contributors[0]['login'], 'ornicar', 'First contributor is ornicar');
-
+// getRepoTags method
+$t->comment('Get tags for a repository');
 $tags = $github->getRepoApi()->getRepoTags('ornicar', 'php-github-api');
-
 $t->ok(count($tags) > 5, 'Found '.count($tags).' tags');
-
 $tagNames = array_keys($tags);
-
 $t->ok($tagNames[0], 'First tag name: '.$tagNames[0]);
 
+// getRepoBranches method
+$t->comment('Get branches for a repository');
 $branches = $github->getRepoApi()->getRepoBranches('ornicar', 'php-github-api');
-
 $t->ok(count($branches) > 0, 'Found '.count($branches).' branch(es)');
-
 $t->ok(isset($branches['master']), 'Found master branch: '.$branches['master']);
 
+// getRepoNetwork method
+$t->comment('Get forks for a repository');
+$network = $github->getRepoApi()->getRepoNetwork('ornicar', 'php-github-api');
+$t->ok(count($network) > 0, 'Found '.count($network).' fork(s)');
+$t->is($network[0]['owner'], 'ornicar', 'First fork is original from ornicar');
+
+// getRepoLanguages method
+$t->comment('Get languages for a repository');
+$languages = $github->getRepoApi()->getRepoLanguages('ornicar', 'php-github-api');
+$t->ok(count($languages) > 0, 'Found '.count($languages).' language(s)');
+$languageNames = array_keys($languages);
+$t->is($languageNames[0], 'PHP', 'First languages is PHP');
 

--- a/test/repoTest.php
+++ b/test/repoTest.php
@@ -9,48 +9,89 @@ $token    = 'fd8144e29b4a85e9487d1cacbcd4e26c';
 
 $github = new phpGitHubApi(true);
 
+// search method
 $t->comment('Search repos');
-
 $repos = $github->getRepoApi()->search('php github api');
-
 $t->ok(count($repos) > 0, 'Found '.count($repos).' repos');
-
 $t->ok(isset($repos[0]['name']), 'First repo name: '.$repos[0]['name']);
 
-$repo = $github->getRepoApi()->show('ornicar', 'php-github-api');
-
-$t->is($repo['name'], 'php-github-api', 'Found repo: '.$repo['name']);
-
 $t->comment('Search repos, specify language');
-
 $repos = $github->getRepoApi()->search('github', 'JavaScript');
-
 $t->is($repos[0]['language'], 'JavaScript', 'First repo language is Javascript');
-
 $repos = $github->getRepoApi()->search('github', 'php');
-
 $t->is($repos[0]['language'], 'PHP', 'First repo language is Php');
+
 $firstPageRepo = $repos[0]['name'];
 
 $t->comment ('Search repos, specify language and start page');
-
 $repos = $github->getRepoApi()->search('github', 'php', 2);
 $t->isnt($repos[0]['name'], $firstPageRepo);
-
 $repos = $github->getRepoApi()->search('github', 'JavaScript');
-
 $t->is($repos[0]['language'], 'JavaScript', 'First repo language is Javascript');
 
-$repo = $github->getRepoApi()->show('ornicar', 'php-github-api');
-
-$t->is($repo['name'], 'php-github-api', 'Found repo: '.$repo['name']);
-
+// getUserRepos method
 $repos = $github->getRepoApi()->getUserRepos('ornicar');
-
 $t->ok(count($repos) > 20, 'Found '.count($repos).' repos');
-
 $t->ok(isset($repos[0]['name']), 'First repo name: '.$repos[0]['name']);
 
+// getPushableRepos method
+$github->authenticate($username, $token, phpGitHubApi::AUTH_HTTP_TOKEN);
+$repos = $github->getRepoApi()->getPushableRepos();
+$t->ok(count($repos) > 0, 'Found '.count($repos).' repos');
+$t->ok(isset($repos[0]['name']), 'First repo name: '.$repos[0]['name']);
+$github->deAuthenticate();
+
+// show method
+$repo = $github->getRepoApi()->show('ornicar', 'php-github-api');
+$t->is($repo['name'], 'php-github-api', 'Found repo: '.$repo['name']);
+
+$collaborators = $github->getRepoApi()->getRepoCollaborators('ornicar', 'php-github-api');
+$t->ok(count($collaborators) > 0, 'Found '.count($collaborators).' collaborators');
+
+// authenticate before repository management tests
+$github->authenticate($username, $token, phpGitHubApi::AUTH_HTTP_TOKEN);
+
+// create method
+$info = $github->getRepoApi()->create('NewRepo', 'new repo description', 'http://github.com', true);
+$t->is($info['name'], 'NewRepo', 'Repo created with name "NewRepo"');
+$t->is($info['description'], 'new repo description', 'Repo created with description "new repo description"');
+$t->is($info['homepage'], 'http://github.com', 'Repo created with homepage "http://github.com"');
+$t->is($info['private'], false, 'Repo created is public');
+
+// setRepoInfo method
+$info = $github->getRepoApi()->setRepoInfo('ornicartest', 'NewRepo', array('description' => 'changed repo description'));
+$t->is($info['description'], 'changed repo description', 'Repo changed to description "changed repo description"');
+
+// getDeployKeys method empty
+$keys = $github->getRepoApi()->getDeployKeys('NewRepo');
+$t->ok(count($keys) == 0, 'No deploy keys setup on NewRepo');
+
+// addDeployKey method
+$key = "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA0yy9pZITu7sCNQdGHggW5hyw734yj5k82kJnLnoA3qLC+t5Q6UyxkWQNeybjv6MQnpV3B+cVr/1/d9G98xG3fOfHU/tMjV5sad+cZTKsyGapL8ut+L2B80uFkKy/zV3gFZZEbDeK4CgzSMgamtMaYKmSyF62/JUI+6lS3LzlzQLbbP+Zkdda5jz6Sm2Fn6nsKm5K6ZWAatUOV9kW/KeutKYLBMyQT3DsZLcrMXtI3rkmfo+p1Nvkjqlq+PLcWU3qF0vssfjdCAuDB1HKeLc4PHNBleupjrOZKAvLHueVv5XQt1fofCDsprBad21Q7uHzWJpEdmadIz+UE+6tqyfqdQ==";
+$keys = $github->getRepoApi()->addDeployKey('newRepo', 'newKey', $key);
+$t->is($keys[0]['title'], 'newKey', 'Key added with title "newKey"');
+$t->is($keys[0]['key'], $key, 'Key added with correct key');
+$t->ok(isset($keys[0]['id']), 'Key got assigned id: ' . $keys[0]['id']);
+$key_id = $keys[0]['id'];
+
+// getDeployKeys method
+$keys = $github->getRepoApi()->getDeployKeys('NewRepo');
+$t->ok(count($keys) == 1, 'Found 1 deploy keys setup on NewRepo');
+
+// removeDeployKeys method
+$keys = $github->getRepoApi()->removeDeployKey('NewRepo', $key_id);
+$t->ok(count($keys) == 0, 'Deploy key removed from NewRepo');
+
+// delete method
+$token = $github->getRepoApi()->delete('NewRepo');
+$t->ok(is_string($token), 'String delete_token is returned');
+$response = $github->getRepoApi()->delete('NewRepo', $token);
+$t->is($response['status'], 'deleted', 'Repo is deleted');
+
+// deauthenticate back to anonymous state
+$github->deAuthenticate();
+
+// getRepo
 $contributors = $github->getRepoApi()->getRepoContributors('ornicar', 'php-github-api');
 $t->ok(count($contributors) > 2, 'Found '.count($contributors).' contributors');
 $t->is($contributors[0]['login'], 'ornicar', 'First contributor is ornicar');
@@ -73,22 +114,4 @@ $t->ok(count($branches) > 0, 'Found '.count($branches).' branch(es)');
 
 $t->ok(isset($branches['master']), 'Found master branch: '.$branches['master']);
 
-$github->authenticate($username, $token);
 
-$info = $github->getRepoApi()->create('NewRepo', 'new repo description', 'http://github.com', true);
-
-$t->is($info['name'], 'NewRepo', 'Repo created with name "NewRepo"');
-
-$t->is($info['description'], 'new repo description', 'Repo created with description "new repo description"');
-
-$t->is($info['homepage'], 'http://github.com', 'Repo created with homepage "http://github.com"');
-
-$t->is($info['private'], false, 'Repo created is public');
-
-$token = $github->getRepoApi()->delete('NewRepo');
-
-$t->ok(is_string($token), 'String delete_token is returned');
-
-$response = $github->getRepoApi()->delete('NewRepo', $token);
-
-$t->is($response['status'], 'deleted', 'Repo is deleted');


### PR DESCRIPTION
I changed the authentication logic a little (backward compatibility maintained) to allow authentication using the HTTP Basic Authentication. According to the Github API documentation (http://develop.github.com/p/general.html), the currently used authentication method, of passing username and token around in the url, is deprecated.
I did quite a lot changes to the Repo API to add all the missing methods that are documented in http://develop.github.com/p/repo.html. Furthermore I changed the existing documentation links to the new location, because the documentation seems to have been moved. The third thing I did was moving some methods around, to get a more logical ordering of the methods.
To the User API I added the Public Key Management methods.

I hope that you will incorporate these changes into your repository.

PS1: I didn't yet write tests for the new methods. 
PS2: I'm planning to do the same for the other methods, so be prepared for some more pull requests :P
