### PR TITLE
initial GitHub oAuth support

### DIFF
--- a/lib/request/phpGitHubApiRequest.php
+++ b/lib/request/phpGitHubApiRequest.php
@@ -139,9 +139,12 @@ class phpGitHubApiRequest
     
     $curlOptions = array();
 
-    if($this->options['login'])
+    if($this->options['login'] || $this->options['auth_method'] == phpGitHubApi::AUTH_OAUTH)
     {
       switch($this->options['auth_method']) {
+        case phpGitHubApi::AUTH_OAUTH:
+          $parameters['access_token'] = $this->options['secret'];
+          break;
         case phpGitHubApi::AUTH_HTTP_PASSWORD:
           $curlOptions += array(
             CURLOPT_USERPWD => $this->options['login'] . ':' . $this->options['secret'],
@@ -162,7 +165,6 @@ class phpGitHubApiRequest
       }
 
     }
-
     if (!empty($parameters))
     {
       $queryString = utf8_encode(http_build_query($parameters, '', '&'));


### PR DESCRIPTION
Source of idea: https://gist.github.com/419219

How to use:
- Get user authorization url:
    $redirectUrl = $api->getUserAuthorizationUrl($client_id, $redirect_url);
- Authenticate:
  - using returned code:
      $api->authenticateOAuth($client_id, $redirect_url, $client_secret, $code);
  - using access_token:
      $api->authenticate(null, $access_token, phpGitHubApi::AUTH_OAUTH);
