### PR TITLE
Adding this options prevents issues when using Github API v3

### DIFF
--- a/lib/Github/HttpClient/Curl.php
+++ b/lib/Github/HttpClient/Curl.php
@@ -63,6 +63,7 @@ class Github_HttpClient_Curl extends Github_HttpClient
             CURLOPT_USERAGENT => $options['user_agent'],
             CURLOPT_FOLLOWLOCATION => true,
             CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_SSL_VERIFYPEER => false,
             CURLOPT_TIMEOUT => $options['timeout']
         );
 


### PR DESCRIPTION
Fixed SSL cert error when trying to use v3 of the api.
