### PR TITLE
Initial pass at adding support for Composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,22 @@
+{
+    "name": "ornicar/github-api",
+    "type": "library",
+    "description": "GitHub API",
+    "homepage": "https://github.com/ornicar/php-github-api",
+    "keywords": ["github", "api", "gist"],
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Thibault Duplessis",
+            "email": "thibault.duplessis@gmail.com",
+            "homepage": "http://ornicar.github.com"
+        }
+    ],
+    "require": {
+        "php": ">=5.2",
+        "ext-curl": "*"
+    },
+    "autoload": {
+        "psr-0": { "Github_": "lib/" }
+    }
+}


### PR DESCRIPTION
Initial pass at adding support for Composer. This will hopefully be enough to get into packagist with a master-dev version. Future tags will be accessible by version numbers if this project continues to use the same naming scheme for tags that it has been using.

I went with `ornicar/github-api` for the package name. I thought `php` might be redundant given composer is really just for PHP packages.
- http://getcomposer.org/
- http://packagist.org/
