### PR TITLE
Version doesn't automatically pick up in composer.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,7 @@
     "name": "ornicar/github-api",
     "type": "library",
     "description": "GitHub API",
+    "version": "3.3",
     "homepage": "https://github.com/ornicar/php-github-api",
     "keywords": ["github", "api", "gist"],
     "license": "MIT",

--- a/lib/Github/HttpClient.php
+++ b/lib/Github/HttpClient.php
@@ -13,11 +13,11 @@ abstract class Github_HttpClient implements Github_HttpClientInterface
      * @var array
      */
     protected $options = array(
-        'protocol'   => 'http',
-        'url'        => ':protocol://github.com/api/v2/:format/:path',
+        'protocol'   => 'https',
+        'url'        => ':protocol://api.github.com/:path',
         'format'     => 'json',
         'user_agent' => 'php-github-api (http://github.com/ornicar/php-github-api)',
-        'http_port'  => 80,
+        'http_port'  => 443,
         'timeout'    => 10,
         'login'      => null,
         'token'      => null


### PR DESCRIPTION
...automatically (X.Y.Z). This is set to NEXT version number.

Alternative is to just use the X.Y.Z format on the next release, so "3.3.0" See http://packagist.org/about

The way to get around it for now if you want to include this package, is to set version to "*" in the require.
